### PR TITLE
Adding explicitely the stdc++fs library for gcc < 9.0 using proper Cmake Module

### DIFF
--- a/CMakeModules/CommonGenevaBuild.cmake
+++ b/CMakeModules/CommonGenevaBuild.cmake
@@ -277,10 +277,8 @@ SET (
 # it is overwritten later by FindGeneva, with the list of full library paths.
 # The function TARGET_LINK_LIBRARIES() can use either variant.
 
-# Add explicitely stdc++fs library in case gcc < 9.0
-# Need to be adapted for other type of compiler ?
 
-SET ( GENEVA_LIBRARIES ${GENEVA_LIBNAMES} $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
+SET ( GENEVA_LIBRARIES ${GENEVA_LIBNAMES})
 
 ################################################################################
 # Add additional libraries if required

--- a/CMakeModules/CommonGenevaBuild.cmake
+++ b/CMakeModules/CommonGenevaBuild.cmake
@@ -276,7 +276,11 @@ SET (
 # This variable contains the library names. In case of an independent build,
 # it is overwritten later by FindGeneva, with the list of full library paths.
 # The function TARGET_LINK_LIBRARIES() can use either variant.
-SET ( GENEVA_LIBRARIES ${GENEVA_LIBNAMES} )
+
+# Add explicitely stdc++fs library in case gcc < 9.0
+# Need to be adapted for other type of compiler ?
+
+SET ( GENEVA_LIBRARIES ${GENEVA_LIBNAMES} $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
 
 ################################################################################
 # Add additional libraries if required

--- a/CMakeModules/IdentifySystemParameters.cmake
+++ b/CMakeModules/IdentifySystemParameters.cmake
@@ -314,6 +314,14 @@ FUNCTION (
 		ENDIF()
 
 	ENDIF()
+
+	IF(CMAKE_CXX_COMPILER_ID MATCHES ${GNU_DEF_IDENTIFIER})
+           # For gnu compiler version < 9.0 add explicitely
+	  IF(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 9.0)
+ 	    SET(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lstdc++fs" PARENT_SCOPE)
+          ENDIF() 
+        ENDIF()
+
 	#--------------------------------------------------------------------------
 
 ENDFUNCTION()


### PR DESCRIPTION
Add stdc++fs as explicit C++ library using the function SET_LINKER_FLAG in IdentifySystemParameter module