### PR TITLE
#21 add 'cpp' file extension to fix compilation bug introduced by raising cmake version in issue #20

### DIFF
--- a/examples/geneva/16_GMPIConsumer/CMakeLists.txt
+++ b/examples/geneva/16_GMPIConsumer/CMakeLists.txt
@@ -52,7 +52,7 @@ ENDIF ()
 SET(EXECUTABLENAME GMPIConsumer)
 
 SET(${EXECUTABLENAME}_SRCS
-        GMPIConsumer
+        GMPIConsumer.cpp
         )
 
 ADD_EXECUTABLE(${EXECUTABLENAME}

--- a/examples/geneva/17_GMPISubClients/CMakeLists.txt
+++ b/examples/geneva/17_GMPISubClients/CMakeLists.txt
@@ -52,8 +52,8 @@ ENDIF ()
 SET ( EXECUTABLENAME GMPISubClients )
 
 SET ( ${EXECUTABLENAME}_SRCS
-	GMPISubClients
-	GMPISubClientParaboloidIndividualMultiD
+	GMPISubClients.cpp
+	GMPISubClientParaboloidIndividualMultiD.cpp
 )
 
 ADD_EXECUTABLE(${EXECUTABLENAME}


### PR DESCRIPTION
Add 'cpp' file extension to fix compilation bug introduced by raising cmake version in issue #20