### PR TITLE
Mpi consumer close all requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 .DS_Store
 .com.apple.*
 build/
-cmake-build-debug/
+cmake-build-*/
 .vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@
 #
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.20 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.13 FATAL_ERROR)
 
 MESSAGE ("")
 

--- a/include/courtier/GMPIConsumerT.hpp
+++ b/include/courtier/GMPIConsumerT.hpp
@@ -1294,8 +1294,8 @@ namespace Gem::Courtier {
                 MPI_Finalize();
             } else {
                 glogger
-                        << "In GMPIConsumerT<>::~GMPIConsumerT():" << std::endl
-                        << "MPI has been finalized before the destructor of GMPIConsumerT has been called."
+                        << "In GMPIConsumerT<>::finalizeMPI():" << std::endl
+                        << "MPI has been finalized GMPIConsumerT::finalizeMPI() has been called."
                         << std::endl
                         << "Happened on node with rank " << m_commRank << std::endl
                         << "This might indicate issues in the user code." << std::endl

--- a/include/courtier/GMPIConsumerT.hpp
+++ b/include/courtier/GMPIConsumerT.hpp
@@ -420,11 +420,9 @@ namespace Gem::Courtier {
 
                 // using break instead of while-condition allows skipping the sleep as soon as receiving has been completed
                 if (receiveIsCompleted) {
-                    // At this point we know that the send call is finished because otherwise we would not have received
-                    // the servers response to our message
-                    // Still, we have to call MPI_Test on the send handle to make the MPI runtime free the resources
-                    int unusedFlag{0};
-                    MPI_Test(&m_sendHandle, &unusedFlag, MPI_STATUS_IGNORE);
+                    // Since we have received the response to our message, the message must have been send out and
+                    // we can therefore allow the send request and send buffer to be freed.
+                    MPI_Request_free(&m_sendHandle);
                     break;
                 }
 

--- a/include/courtier/GMPIConsumerT.hpp
+++ b/include/courtier/GMPIConsumerT.hpp
@@ -1381,6 +1381,9 @@ namespace Gem::Courtier {
                             << m_commonConfig.waitForMasterStartupTimeoutSec << "s." << std::endl
                             << "Trying to continue unsynchronized." << std::endl
                             << GWARNING;
+                    
+                    MPI_Cancel(&requestHandle);
+                    MPI_Request_free(&requestHandle);
 
                     return false; // synchronize stopped but unsuccessful
                 } else if (m_commonConfig.waitForMasterStartupPollIntervalUSec > 0) {

--- a/scripts/genevaConfig.gcfg
+++ b/scripts/genevaConfig.gcfg
@@ -65,6 +65,10 @@ CMAKE="/usr/bin/cmake"
 #BOOSTLIBS="/usr/lib"
 #BOOSTINCL="/usr/include"
 
+# Specify the root path of your MPI installation i.e. that among others contains the directories lib/ and bin/
+# If empty, CMake searches for a default MPI installation that might not be the desired one if multiple installations exist
+MPIROOT=""
+
 # Build mode must be either 'Release', 'Debug', 'RelWithDebInfo',
 # 'MinSizeRel' or 'Sanitize'. NOTE: the 'Sanitize' setting is experimental!
 # It will default to 'Debug' on unsupported platforms; see

--- a/scripts/prepareBuild.sh
+++ b/scripts/prepareBuild.sh
@@ -60,6 +60,7 @@ if [ $# -eq 0 ]; then
 	BUILDSTATIC="0"                # Whether to build static code / libraries (experimental!)
 	VERBOSEMAKEFILE="1"            # Whether compilation information should be emitted
 	INSTALLDIR="/opt/geneva"       # Where the Geneva library shall go
+	MPIROOT=""                     # Root directory of the MPI installation, empty for automatic find through Cmake
 	BUILDMPICONSUMER="1"           # Whether to build the MPI-consumer of the courtier library
 	BUILDOPENCLEXAMPLES="0"        # Whether to build OpenCL examples (note: this is an experimental feature)
 elif [ $# -eq 1 ]; then
@@ -126,6 +127,11 @@ elif [ $# -eq 1 ]; then
   	BUILDMPICONSUMER="1"
   	echo "Variable BUILDMPICONSUMER wasn't set. Setting to default value '${BUILDMPICONSUMER}'"
   fi
+
+    if [ -z "${MPIROOT}" ]; then
+      	MPIROOT=""
+      	echo "Variable MPIROOT not specified, setting MPIROOT to empty string, indicating automatic find through CMake."
+    fi
 
 	if [ -z "${BUILDOPENCLEXAMPLES}" ]; then
 		BUILDOPENCLEXAMPLES="0"
@@ -285,6 +291,10 @@ CONFIGURE="${CMAKE} $BOOSTLOCATIONPATHS $BOOSTSYSTEMFLAG \
 -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} \
 -DGENEVA_BUILD_WITH_MPI_CONSUMER=${BUILDMPICONSUMER} \
 -DGENEVA_BUILD_WITH_OPENCL_EXAMPLES=${BUILDOPENCLEXAMPLES}"
+
+if [ "x$MPIROOT" != "x" ]; then
+	CONFIGURE="${CONFIGURE} -DMPI_HOME='${MPIROOT}'"
+fi
 
 if [ "x$CXXEXTRAFLAGS" != "x" ]; then
 	CONFIGURE="${CONFIGURE} -DCMAKE_CXX_FLAGS='${CXXEXTRAFLAGS}'"


### PR DESCRIPTION
Summarization of the changes:
1. In some cases, MPIConsumerT was not closing open MPI requests. This has been fixed in c774197337ff2d8737705d1f352a62c30f37b5c3 and 52020d724055a5b82d69ed2dcfa5fc1d900ed974.
2. We exclude all build directories produced by Clion from git using a wildcard.
3. We set the Cmake minimum version DOWN TO 3.13. This is the version available at GSI and has worked without issues.
4. The Cmake file and the build config file have now a parameter to set the MPI version explicitly. This is necessary if there are multiple MPI versions available on the system an a particular shall be chosen.
5. A misleading warning, claiming MPI has already been finalized when users use MPI themselves and execute without MPIConsumerT has been removed 

The new version has been tested at GSI and works.
Please review the lower Cmake version. At GSI it was no problem to build the library with MPI Consumer and examples with CMAKE 3.13.