### PR TITLE
#30 break cyclic shared pointer relationship between broker and consumers

### DIFF
--- a/include/courtier/GAsioConsumerT.hpp
+++ b/include/courtier/GAsioConsumerT.hpp
@@ -1093,7 +1093,7 @@ private:
 		 std::shared_ptr<processable_type> p;
 
 		 // Try to retrieve a work item from the broker
-		 m_broker_ptr->get(p, m_timeout);
+		 GBROKER(processable_type)->get(p, m_timeout);
 
 		 // May be empty, if we ran into a timeout
 		 return p;
@@ -1112,7 +1112,7 @@ private:
 			 );
 		 }
 
-		 if(not m_broker_ptr->put(p, m_timeout)) {
+		 if(not GBROKER(processable_type)->put(p, m_timeout)) {
 			 glogger
 				 << "In GAsioConsumerT<>::putPayloadItem():" << std::endl
 				 << "Work item could not be submitted to the broker" << std::endl
@@ -1185,7 +1185,6 @@ private:
 	 std::atomic<std::size_t> m_n_active_sessions{0};
 	 std::size_t m_n_max_reconnects = GASIOCONSUMERMAXCONNECTIONATTEMPTS;
 
-	 std::shared_ptr<typename Gem::Courtier::GBrokerT<processable_type>> m_broker_ptr = GBROKER(processable_type); ///< Simplified access to the broker
 	 const std::chrono::duration<double> m_timeout = std::chrono::milliseconds(GBEASTMSTIMEOUT); ///< A timeout for put- and get-operations via the broker
 
 	 //-------------------------------------------------------------------------

--- a/include/courtier/GMPIConsumerT.hpp
+++ b/include/courtier/GMPIConsumerT.hpp
@@ -996,7 +996,7 @@ namespace Gem::Courtier {
             std::shared_ptr<processable_type> p;
 
             // Try to retrieve a work item from the broker
-            m_brokerPtr->get(p, m_timeout);
+            GBROKER(processable_type)->get(p, m_timeout);
 
             // May be empty, if we ran into a timeout
             return p;
@@ -1014,7 +1014,7 @@ namespace Gem::Courtier {
                                 << "Function called with empty work item" << std::endl);
             }
 
-            if (not m_brokerPtr->put(p, m_timeout)) {
+            if (not GBROKER(processable_type)->put(p, m_timeout)) {
                 glogger
                         << "In GMPIConsumerMasterNodeT<>::putPayloadItem():" << std::endl
                         << "Work item could not be submitted to the broker" << std::endl
@@ -1048,9 +1048,6 @@ namespace Gem::Courtier {
         std::vector<std::shared_ptr<GMPIConsumerSessionT<processable_type>>> m_openSessions{};
         // whether a stop request for the GMPIConsumerT has been received
         std::atomic_bool m_isToldToStop;
-        // whether the stop request has been sent to all clients
-        std::shared_ptr<typename Gem::Courtier::GBrokerT<processable_type>> m_brokerPtr = GBROKER(
-                processable_type); ///< Simplified access to the broker
         const std::chrono::duration<double> m_timeout = std::chrono::milliseconds(
                 GMPICONSUMERBROKERACCESSBROKERTIMEOUT); ///< A timeout for put- and get-operations via the broker
     };

--- a/include/courtier/GSerialConsumerT.hpp
+++ b/include/courtier/GSerialConsumerT.hpp
@@ -244,14 +244,14 @@ private:
 					 const std::chrono::milliseconds& timeout
 				 ) -> std::shared_ptr<processable_type> {
 					 std::shared_ptr<processable_type> p;
-					 m_broker_ptr->get(p, timeout);
+					 GBROKER(processable_type)->get(p, timeout);
 					 return p;
 				 }
 				 //----------------------
 				 , [this](
 					 std::shared_ptr<processable_type> p
 					 , const std::chrono::milliseconds& timeout
-				 ) -> void { m_broker_ptr->put(p, timeout); }
+				 ) -> void { GBROKER(processable_type)->put(p, timeout); }
 				 //----------------------
 				 , [this]() -> bool { return this->stopped(); }
 				 //----------------------
@@ -304,7 +304,6 @@ private:
 	 std::shared_ptr<GLocalConsumerWorkerT<processable_type>> m_worker; ///< Holds the worker assigned to this consumer
 	 std::shared_ptr<GLocalConsumerWorkerT<processable_type>> m_workerTemplate; ///< Holds an external worker assigned to this consumer
 
-	 std::shared_ptr<GBrokerT<processable_type>> m_broker_ptr = GBROKER(processable_type); ///< A shortcut to the broker so we do not have to go through the singleton
 };
 
 /******************************************************************************/

--- a/include/courtier/GStdThreadConsumerT.hpp
+++ b/include/courtier/GStdThreadConsumerT.hpp
@@ -334,14 +334,14 @@ private:
 						 const std::chrono::milliseconds& timeout
 					 ) -> std::shared_ptr<processable_type> {
 						 std::shared_ptr<processable_type> p;
-						 m_broker_ptr->get(p, timeout);
+						 GBROKER(processable_type)->get(p, timeout);
 						 return p;
 					 }
 					 //----------------------
 					 , [this](
 						 std::shared_ptr<processable_type> p
 						 , const std::chrono::milliseconds& timeout
-					 ) -> void { m_broker_ptr->put(p, timeout); }
+					 ) -> void { GBROKER(processable_type)->put(p, timeout); }
 					 //----------------------
 					 , [this]() -> bool { return this->stopped(); }
 					 //----------------------
@@ -398,8 +398,6 @@ private:
 
 	 std::vector<std::shared_ptr<GLocalConsumerWorkerT<processable_type>>> m_workers; ///< Holds the current worker objects
 	 std::shared_ptr<GLocalConsumerWorkerT<processable_type>> m_workerTemplate; ///< All workers will be created as a clone of this worker
-
-	 std::shared_ptr<GBrokerT<processable_type>> m_broker_ptr = GBROKER(processable_type); ///< A shortcut to the broker so we do not have to go through the singleton
 };
 
 /******************************************************************************/

--- a/include/courtier/GWebsocketConsumerT.hpp
+++ b/include/courtier/GWebsocketConsumerT.hpp
@@ -1409,7 +1409,7 @@ private:
 		 std::shared_ptr<processable_type> p;
 
 		 // Try to retrieve a work item from the broker
-		 m_broker_ptr->get(p, m_timeout);
+		 GBROKER(processable_type)->get(p, m_timeout);
 
 		 // May be empty, if we ran into a timeout
 		 return p;
@@ -1428,7 +1428,7 @@ private:
 			 );
 		 }
 
-		 if(not m_broker_ptr->put(p, m_timeout)) {
+		 if(not GBROKER(processable_type)->put(p, m_timeout)) {
 			 glogger
 				 << "In GWebsocketConsumerT<>::putPayloadItem():" << std::endl
 				 << "Work item could not be submitted to the broker" << std::endl
@@ -1502,7 +1502,6 @@ private:
 	 std::size_t m_ping_interval = GBEASTCONSUMERPINGINTERVAL;
 	 bool m_verbose_control_frames = false; ///< Whether the control_callback should emit information when a control frame is received
 
-	 std::shared_ptr<GBrokerT<processable_type>> m_broker_ptr = GBROKER(processable_type); ///< Simplified access to the broker
 	 const std::chrono::duration<double> m_timeout = std::chrono::milliseconds(GBEASTMSTIMEOUT); ///< A timeout for put- and get-operations via the broker
 
 	 //-------------------------------------------------------------------------


### PR DESCRIPTION
The fix has been tested at GSI.
Compilation works without issues.
GStarter has been tested with all consumers (singlethreaded, multithread, asio, beast, mpi) and works fine.
I think, it is ready to merge.